### PR TITLE
feat(grpc): remove non-success status

### DIFF
--- a/spec/durable-promises.proto
+++ b/spec/durable-promises.proto
@@ -42,7 +42,6 @@ message ReadPromiseRequest {
 }
 
 message ReadPromiseResponse {
-  bool wrote = 1;
   Promise promise = 2;
 }
 
@@ -54,7 +53,6 @@ message SearchPromisesRequest {
 }
 
 message SearchPromisesResponse {
-  bool wrote = 1;
   string cursor = 2;
   repeated Promise promises = 3;
 }
@@ -68,7 +66,7 @@ message CreatePromiseRequest {
 }
 
 message CreatePromiseResponse {
-  bool wrote = 1;
+  bool noop = 1;
   Promise promise = 2;
 }
 
@@ -80,7 +78,7 @@ message CancelPromiseRequest {
 }
 
 message CancelPromiseResponse {
-  bool wrote = 1;
+  bool noop = 1;
   Promise promise = 2;
 }
 
@@ -92,7 +90,7 @@ message ResolvePromiseRequest {
 }
 
 message ResolvePromiseResponse {
-  bool wrote = 1;
+  bool noop = 1;
   Promise promise = 2;
 }
 
@@ -104,7 +102,7 @@ message RejectPromiseRequest {
 }
 
 message RejectPromiseResponse {
-  bool wrote = 1;
+  bool noop = 1;
   Promise promise = 2;
 }
 

--- a/spec/durable-promises.proto
+++ b/spec/durable-promises.proto
@@ -42,7 +42,7 @@ message ReadPromiseRequest {
 }
 
 message ReadPromiseResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   Promise promise = 2;
 }
 
@@ -54,7 +54,7 @@ message SearchPromisesRequest {
 }
 
 message SearchPromisesResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   string cursor = 2;
   repeated Promise promises = 3;
 }
@@ -68,7 +68,7 @@ message CreatePromiseRequest {
 }
 
 message CreatePromiseResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   Promise promise = 2;
 }
 
@@ -80,7 +80,7 @@ message CancelPromiseRequest {
 }
 
 message CancelPromiseResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   Promise promise = 2;
 }
 
@@ -92,7 +92,7 @@ message ResolvePromiseRequest {
 }
 
 message ResolvePromiseResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   Promise promise = 2;
 }
 
@@ -104,7 +104,7 @@ message RejectPromiseRequest {
 }
 
 message RejectPromiseResponse {
-  bool wrote = 1; 
+  bool wrote = 1;
   Promise promise = 2;
 }
 

--- a/spec/durable-promises.proto
+++ b/spec/durable-promises.proto
@@ -33,13 +33,8 @@ enum SearchState {
 }
 
 enum Status {
-  UNKNOWN = 0;
   OK = 200;
   CREATED = 201;
-  NOCONTENT = 204;
-  FORBIDDEN = 403;
-  NOTFOUND = 404;
-  CONFLICT = 409;
 }
 
 message Value {

--- a/spec/durable-promises.proto
+++ b/spec/durable-promises.proto
@@ -32,11 +32,6 @@ enum SearchState {
   SEARCH_REJECTED = 3;
 }
 
-enum Status {
-  OK = 200;
-  CREATED = 201;
-}
-
 message Value {
   map<string, string> headers = 1;
   bytes data = 3;
@@ -47,7 +42,7 @@ message ReadPromiseRequest {
 }
 
 message ReadPromiseResponse {
-  Status status = 1;
+  bool wrote = 1; 
   Promise promise = 2;
 }
 
@@ -59,7 +54,7 @@ message SearchPromisesRequest {
 }
 
 message SearchPromisesResponse {
-  Status status = 1;
+  bool wrote = 1; 
   string cursor = 2;
   repeated Promise promises = 3;
 }
@@ -73,7 +68,7 @@ message CreatePromiseRequest {
 }
 
 message CreatePromiseResponse {
-  Status status = 1;
+  bool wrote = 1; 
   Promise promise = 2;
 }
 
@@ -85,7 +80,7 @@ message CancelPromiseRequest {
 }
 
 message CancelPromiseResponse {
-  Status status = 1;
+  bool wrote = 1; 
   Promise promise = 2;
 }
 
@@ -97,7 +92,7 @@ message ResolvePromiseRequest {
 }
 
 message ResolvePromiseResponse {
-  Status status = 1;
+  bool wrote = 1; 
   Promise promise = 2;
 }
 
@@ -109,7 +104,7 @@ message RejectPromiseRequest {
 }
 
 message RejectPromiseResponse {
-  Status status = 1;
+  bool wrote = 1; 
   Promise promise = 2;
 }
 


### PR DESCRIPTION
non-success status should be returned as grpc errors. the status in responses should be used only to capture dedup logic of the successful call (a.k.a. did this request change something in the database or not) to keep the experience consistent to http. 